### PR TITLE
Updated riemann version, removed sudo from start-riemann.sh, exposed UDP port 5555

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,7 +17,7 @@ FROM stealthly/docker-ruby
 
 RUN gem install riemann-client riemann-tools riemann-dash
 
-ENV RIEMANN_VERSION 0.2.4
+ENV RIEMANN_VERSION 0.2.10
 ENV RIEMANN_RELEASE riemann-$RIEMANN_VERSION
 ENV RIEMANN_URL http://aphyr.com/riemann/$RIEMANN_RELEASE.tar.bz2
 ENV RIEMANN_HOME /opt/$RIEMANN_RELEASE

--- a/start-riemann.sh
+++ b/start-riemann.sh
@@ -1,2 +1,2 @@
 #!/bin/bash
-sudo docker run -d --name="riemann" -h $1 -e HOST="$1" -p 4567:4567 -p 5555:5555 -p 5556:5556 stealthly/docker-riemann
+docker run -d --name="riemann" -h $1 -e HOST="$1" -p 4567:4567 -p 5555:5555 -p 5555:5555/udp -p 5556:5556 stealthly/docker-riemann


### PR DESCRIPTION
Regarding sudo, I think that should be up to the individual user. Personally I've configured docker so that I don't need sudo to run a container and I don't want to type my password in unnecessarily. I also think others wouldn't want to unknowingly sudo a command.
